### PR TITLE
Detangle dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["es2015", "stage-2", "react"]
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,22 +1,4 @@
 {
-  parser: "babel-eslint",
-  extends: "airbnb",
-  settings: {
-    'import/resolver': {
-      webpack: {}
-    }
-  },
-  rules: {
-    "react/jsx-filename-extension": "off",
-    "react/require-default-props": "off",
-    "import/extensions": [ 1, "never" ],
-    "no-console": "off",
-    "no-alert": "off",
-    "quote-props": "off",
-    "key-spacing": "off",
-    "one-var": "off",
-    "one-var-declaration-per-line": [ 1, "initializations" ],
-    "max-len": "off",
-    "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"]
-  }
+  "extends": "stripes",
+  "parser": "babel-eslint"
 }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,6 @@
     "stripes-redux": "./index.js"
   },
   "devDependencies": {
-    "babel-core": "^6.17.0",
-    "babel-eslint": "^7.0.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-2": "^6.18.0",
-    "babel-register": "^6.18.0",
     "chai": "^4.0.2",
     "enzyme": "^2.6.0",
     "eslint": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -17,15 +17,11 @@
     "stripes-redux": "./index.js"
   },
   "devDependencies": {
+    "babel-eslint": "^8.0.0",
     "chai": "^4.0.2",
     "enzyme": "^2.6.0",
-    "eslint": "^3.8.0",
-    "eslint-config-airbnb": "^14.1.0",
-    "eslint-import-resolver-webpack": "^0.8.1",
-    "eslint-plugin-babel": "^4.0.1",
-    "eslint-plugin-import": "^2.0.1",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.4.1",
+    "eslint": "^4.7.2",
+    "eslint-config-stripes": "^0.0.1",
     "fetch-mock": "^5.6.2",
     "jsdom": "^11.0.0",
     "jsdom-global": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,11 @@
   },
   "devDependencies": {
     "babel-eslint": "^8.0.0",
-    "chai": "^4.0.2",
-    "enzyme": "^2.6.0",
     "eslint": "^4.7.2",
     "eslint-config-stripes": "^0.0.1",
-    "fetch-mock": "^5.6.2",
-    "jsdom": "^11.0.0",
-    "jsdom-global": "^3.0.2",
-    "mocha": "^3.1.2"
+    "redux": "^3.7.2",
+    "rxjs": "^5.4.3",
+    "webpack": "^3.6.0"
   },
   "dependencies": {
     "redux-observable": "^0.15.0"

--- a/src/epics.js
+++ b/src/epics.js
@@ -1,6 +1,6 @@
 import { combineEpics, createEpicMiddleware } from 'redux-observable';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject'; // eslint-disable-line
-import 'rxjs/add/operator/mergeMap'; // eslint-disable-line
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import 'rxjs/add/operator/mergeMap';
 
 export default function configureEpics(...initialEpics) {
   const epic$ = new BehaviorSubject(combineEpics(...initialEpics));


### PR DESCRIPTION
When `stripes-core` moved from `eslint-preset-es2015` to `eslint-preset-env`, it broke applications that included `stripes-redux` with `Module build failed: Error: Couldn't find preset "es2015"`.

Since stripes-redux will never be built as an application on its own, there's no reason for it to have its own babel config.

This PR also removes unnecessary devDependencies, aligns on `eslint-config-stripes`, and cleans up all `peerDependencies` warnings.